### PR TITLE
Upgrade code missing

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -6,6 +6,51 @@ function xmldb_ouwiki_upgrade($oldversion=0) {
 
     $dbman = $DB->get_manager(); /// loads ddl manager and xmldb classes
 
+    if ($oldversion < 2008100600) {
+
+        /// Define field deletedat to be added to ouwiki_versions
+        $table = new xmldb_table('ouwiki_versions');
+        $field = new xmldb_field('deletedat');
+        $field->set_attributes(XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, null, 'changeprevsize');
+        /// Launch add field deletedat (provided field does not already exist)
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_mod_savepoint(true, 2008100600, 'ouwiki');
+    }
+
+    if ($oldversion < 2009120801) {
+        /// Launch create table for ouwiki_annotations - if it does not already exist (extra precaution)
+        $table = new xmldb_table('ouwiki_annotations');
+        if(!$dbman->table_exists($table)) {
+            $dbman->install_one_table_from_xmldb_file($CFG->dirroot.'/mod/ouwiki/db/install.xml', 'ouwiki_annotations');
+        }
+
+        /// Define field locked to be added to ouwiki_pages
+        $table = new xmldb_table('ouwiki_pages');
+        $field = new xmldb_field('locked');
+        $field->set_attributes(XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, 0, 'currentversionid');
+        /// Launch add field locked - if it does not already exist (extra precaution)
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_mod_savepoint(true, 2009120801, 'ouwiki');
+    }
+
+    if ($oldversion < 2010022300) {
+
+        /// Define field locked to be added to ouwiki_pages
+        $table = new xmldb_table('ouwiki');
+        $field = new xmldb_field('commenting');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '20', null, null, null, 'default', 'completionedits');
+        /// Launch add field locked - if it does not already exist (extra precaution)
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2010022300, 'ouwiki');
+    }
+
     if ($oldversion < 2010122001) {
 
         // Drop the old comments table


### PR DESCRIPTION
Hi there,

It seems when porting ouwiki to moodle 2, the upgrade history was wiped and started fresh instead of updating it to m2. This means only moodle 1.9's with the absolute latest ouwiki prior to the m2 jump will successfully upgrade.

This patch adds a bunch of the upgrade from earlier 1.9 releases so the relevant table (annotations) and fields (locked, deletedat, commenting) are added where necessary (all with the usual checks to make sure they don't already exist).

Regards,
Adam Olley
NetSpot Pty. Ltd.
