### PR TITLE
Suggested fix for "modulemissingcode" error while running course partici...

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -735,3 +735,19 @@ function ouwiki_cron() {
                 $e->getTraceAsString()."\n\n");
     }
 }
+
+/**
+ * List of view style log actions
+ * @return array
+ */
+function ouwiki_get_view_actions() {
+    return array('view','view all', 'viewold', 'viewhistory', 'viewindex');
+}
+
+/**
+ * List of update style log actions
+ * @return array
+ */
+function ouwiki_get_post_actions() {
+    return array('update', 'add', 'add comment', 'add post', 'edit post', 'annotate', 'history');
+}


### PR DESCRIPTION
...pation report

*getview_actions() and *getpost_actions() were missing from ouwiki/lib.php

Hope I got all the "action"s right :-)

I am basing my action logging suggestions on the attached usage count for various ouwiki "action"s on one of our servers.

ACTION  COUNT( \* )
add 29
annotate    2
diff    56
edit    1205
entirewiki  36
history 216
lock    2
participation   169
revert  21
search  6
unlock  1
update  36
userparticipation   134
view    3459
view all    1
viewold 131
wikihistory 173
wikiindex   256
