### PR TITLE
ensure images in intro field render correctly

### DIFF
--- a/index.php
+++ b/index.php
@@ -85,6 +85,10 @@ foreach ($ouwikis as $ouwiki) {
     }
     $link = html_writer::link(new moodle_url('/mod/ouwiki/view.php', array('id' => $ouwiki->coursemodule)), $ouwiki->name, $linkcss);
 
+    // properly format the intro
+    $contextmodule = get_context_instance(CONTEXT_MODULE, $ouwiki->coursemodule);
+    $ouwiki->intro = file_rewrite_pluginfile_urls($ouwiki->intro, 'pluginfile.php', $contextmodule->id, 'mod_ouwiki', 'intro', null);
+
     if ($usesections) {
         $table->data[] = array(get_section_name($course, $sections[$ouwiki->section]), $link, $ouwiki->intro);
     } else {


### PR DESCRIPTION
Wiki intro fields can contain HTML includes images. 

This fix ensures the URL to the image is rendered appropriately. 
