### PR TITLE
Fix Individual Activity Reports summaries

### DIFF
--- a/lang/en/ouwiki.php
+++ b/lang/en/ouwiki.php
@@ -291,7 +291,7 @@ $string['typeinsectionname']='Type section title here';
 $string['addnewsection']='Add new section to this page';
 $string['createdbyon'] = 'created by {$a->name} on {$a->date}';
 
-$string['numedits'] = '{$a} edit(s)';
+$string['numedits'] = '{$a} edits';
 $string['overviewnumentrysince1'] = 'new wiki entry since last login.';
 $string['overviewnumentrysince'] = 'new wiki entries since last login.';
 

--- a/styles.css
+++ b/styles.css
@@ -900,3 +900,8 @@ a.ouwiki_noshow:link,a.ouwiki_noshow:visited {
     font-size: 0.8em;
     margin-left: 5px;
 }
+
+#page-report-outline-user .ouwiki_user_complete_report h2 {
+    font: inherit;
+}
+


### PR DESCRIPTION
Fixes ouwiki_user_outline(), so the outline activity report displays the number of edits, the grade and the time of the last edit.  Also changes the language string to be more consistent with the other activities.

Adds ouwiki_user_complete() function to include a copy of the user's participation table in the complete  report.  Where the wiki has been setup as one per group, it displays the table for each group the user is a member of.

Addresses issue #43 raised a few days ago.