### PR TITLE
Fix bug with control characters

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -308,6 +308,8 @@ function ouwiki_init_pages($course, $cm, $ouwiki, $subwiki) {
         }
 
         $content = $xmlfile->get_content();
+        $content = preg_replace('/[\x00-\x1F\x7F]/', '', $content);
+        
         $xml =  new DOMDocument();
         $xml->loadXML($content);
         if (!$xml) {


### PR DESCRIPTION
We had  a problem with some control characters getting in the exported versions of our OUWikis.

This fix solved our problem.
