### PR TITLE
Fix duplicate index keys

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -467,18 +467,9 @@ WHERE
 
         // Define index ouwiki_subwikis_unique_group (unique) to be added to ouwiki_subwikis.
         $table = new xmldb_table('ouwiki_subwikis');
-        $index = new xmldb_index('ouwiki_subwikis_unique_group', XMLDB_INDEX_UNIQUE, array('wikiid', 'groupid'));
+        $index = new xmldb_index('ouwiki_subwikis_unique_group', XMLDB_INDEX_UNIQUE, array('wikiid', 'groupid', 'userid'));
 
         // Conditionally launch add index ouwiki_subwikis_unique_group.
-        if (!$dbman->index_exists($table, $index)) {
-            $dbman->add_index($table, $index);
-        }
-
-        // Define index ouwiki_subwikis_unique_user (unique) to be added to ouwiki_subwikis.
-        $table = new xmldb_table('ouwiki_subwikis');
-        $index = new xmldb_index('ouwiki_subwikis_unique_user', XMLDB_INDEX_UNIQUE, array('wikiid', 'userid'));
-
-        // Conditionally launch add index ouwiki_subwikis_unique_user.
         if (!$dbman->index_exists($table, $index)) {
             $dbman->add_index($table, $index);
         }


### PR DESCRIPTION
Produces error "ORA-01452: Cannot CREATE UNIQUE INDEX; duplicate keys found" b/c it adds two indices to ouwiki subwiki table.
When subwiki is a group, user is null, so wiki-user index is not unique -- and vise versa when subwiki is for user.
You can either create a single three-field index (wiki-group-user) or drop indices altogether.